### PR TITLE
Update ApiConfig to use environment variable for base URL

### DIFF
--- a/src/services/ApiConfig.js
+++ b/src/services/ApiConfig.js
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:8080';
-
 const apiClient = axios.create({
-  baseURL: API_BASE_URL,
+  baseURL: import.meta.env.VITE_API_URL,
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
This pull request updates the API configuration to make the base URL dynamic, allowing it to be set via environment variables. 

Configuration changes:

* [`src/services/ApiConfig.js`](diffhunk://#diff-21f7ad43aaa7ba7b4a11b6b15dd40e3088120e79496f38adcf5f49f539742a85L3-R4): Replaced the hardcoded `API_BASE_URL` with `import.meta.env.VITE_API_URL` to dynamically set the base URL from environment variables.